### PR TITLE
Bugfix: Wizard generates empty project

### DIFF
--- a/plugins/fr.inria.diverse.melange.ui/plugin.xml
+++ b/plugins/fr.inria.diverse.melange.ui/plugin.xml
@@ -609,7 +609,7 @@
            name="Melange">
      </category>
      <wizard
-           canFinishEarly="true"
+           canFinishEarly="false"
            category="fr.inria.diverse.melange.category"
            class="fr.inria.diverse.melange.ui.wizards.NewMelangeProjectWizard"
            icon="icons/melange.png"


### PR DESCRIPTION
```
Set the var "canFinishEarly" in the plugin.xml file to false for the wizard extension point.
This would prevent the wizard to finish early and generate an mpty project.
```
