### PR TITLE
Prettify the outline for .melange file

### DIFF
--- a/plugins/fr.inria.diverse.melange.ui/src/main/java/fr/inria/diverse/melange/ui/labeling/MelangeLabelProvider.xtend
+++ b/plugins/fr.inria.diverse.melange.ui/src/main/java/fr/inria/diverse/melange/ui/labeling/MelangeLabelProvider.xtend
@@ -7,6 +7,10 @@ import fr.inria.diverse.melange.metamodel.melange.Language
 import fr.inria.diverse.melange.metamodel.melange.ModelType
 import fr.inria.diverse.melange.metamodel.melange.ModelTypingSpace
 import fr.inria.diverse.melange.metamodel.melange.Transformation
+import org.eclipse.emf.ecore.EAttribute
+import org.eclipse.emf.ecore.EOperation
+import org.eclipse.emf.ecore.EParameter
+import org.eclipse.emf.ecore.EReference
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider
 import org.eclipse.xtext.common.types.JvmDeclaredType
 import org.eclipse.xtext.xbase.ui.labeling.XbaseLabelProvider
@@ -57,5 +61,21 @@ class MelangeLabelProvider extends XbaseLabelProvider
 
 	def String text(Language l) {
 		return '''«l.name»«FOR t : l.superLanguages BEFORE '\u25C0' SEPARATOR ', '»«t.name»«ENDFOR»«FOR t : l.implements BEFORE ' \u25C1 ' SEPARATOR ', '»«t.name»«ENDFOR»'''.toString
+	}
+
+	def String text(EAttribute a){
+	    return '''«a.name» : «a.EType.name»'''
+	}
+
+	def String text(EReference r){
+	    return '''«r.name» : «r.EType.name»'''
+	}
+
+	def String text(EOperation o){
+	    return '''«o.name» : «o.EType.name»'''
+	}
+
+	def String text(EParameter p){
+	    return '''«p.name» : «p.EType.name»'''
 	}
 }

--- a/plugins/fr.inria.diverse.melange.ui/src/main/java/fr/inria/diverse/melange/ui/outline/MelangeOutlineTreeProvider.xtend
+++ b/plugins/fr.inria.diverse.melange.ui/src/main/java/fr/inria/diverse/melange/ui/outline/MelangeOutlineTreeProvider.xtend
@@ -7,6 +7,9 @@ import fr.inria.diverse.melange.metamodel.melange.Metamodel
 import fr.inria.diverse.melange.metamodel.melange.ModelType
 import fr.inria.diverse.melange.metamodel.melange.Transformation
 import org.eclipse.emf.codegen.ecore.genmodel.GenModel
+import org.eclipse.emf.ecore.EAnnotation
+import org.eclipse.emf.ecore.EPackage
+import org.eclipse.emf.ecore.EStructuralFeature
 import org.eclipse.xtext.common.types.JvmTypeReference
 import org.eclipse.xtext.ui.editor.outline.IOutlineNode
 import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider
@@ -17,6 +20,10 @@ class MelangeOutlineTreeProvider extends DefaultOutlineTreeProvider
 
 	def boolean _isLeaf(Transformation t) {
 		return true
+	}
+
+	def boolean _isLeaf(EStructuralFeature a){
+	    return true
 	}
 
     def void _createNode(IOutlineNode parentNode, JvmTypeReference ref) {
@@ -31,36 +38,37 @@ class MelangeOutlineTreeProvider extends DefaultOutlineTreeProvider
 		// Nope
 	}
 
+	def void _createNode(IOutlineNode parentNode, EAnnotation a){
+	    // Nope
+	}
+
+
 	def void _createNode(IOutlineNode parentNode, ModelType mt) {
 		val mNode = createEObjectNode(parentNode, mt)
 
 		mt.pkgs.forEach[pkg |
-			val pkgNode = createEObjectNode(mNode, pkg, imageDispatcher.invoke(pkg), textDispatcher.invoke(pkg),
-				isLeafDispatcher.invoke(pkg))
-
-			pkg.EClassifiers.forEach[cls |
-				createEObjectNode(pkgNode, cls, imageDispatcher.invoke(cls), textDispatcher.invoke(cls),
-					isLeafDispatcher.invoke(cls))
-			]
+		    createNode(mNode, pkg)
 		]
 	}
 
 	def void _createNode(IOutlineNode parentNode, Language l) {
 		val mNode = createEObjectNode(parentNode, l)
 
-		l.syntax.pkgs.forEach[pkg |
-			val pkgNode = createEObjectNode(mNode, pkg, imageDispatcher.invoke(pkg), textDispatcher.invoke(pkg),
-				isLeafDispatcher.invoke(pkg))
-
-			pkg.EClassifiers.forEach[cls |
-				createEObjectNode(pkgNode, cls, imageDispatcher.invoke(cls), textDispatcher.invoke(cls),
-					isLeafDispatcher.invoke(cls))
-			]
+		l.syntax.pkgs.filter[ESuperPackage === null].forEach[pkg |
+		    createNode(mNode, pkg)
 		]
 
 		l.semantics.forEach[asp |
-			createEObjectNode(mNode, asp, imageDispatcher.invoke(asp), textDispatcher.invoke(asp),
-				isLeafDispatcher.invoke(asp))
+		    createNode(mNode, asp)
 		]
 	}
+
+    def void _createNode(IOutlineNode parentNode, EPackage p){
+        val mNode = createEObjectNode(parentNode, p)
+
+        p.ESubpackages.forEach[pkg |
+            createNode(mNode, pkg)
+        ]
+    }
+
 }


### PR DESCRIPTION
Prettify the Outline for .melange file by :
- modifying the text of ETypedElement in "name : type"
- removing the nodes for EAnnotations
- adding support for package hierarchy
- symplying the Outline tree generation
