### PR TITLE
Add use of a transaction when the Language has an editing domain

### DIFF
--- a/plugins/fr.inria.diverse.melange/META-INF/MANIFEST.MF
+++ b/plugins/fr.inria.diverse.melange/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Require-Bundle: org.eclipse.xtext;bundle-version="[2.7.0,2.10.0)";visibility:=re
  org.eclipse.pde.core;bundle-version="3.10.1",
  fr.inria.diverse.melange.adapters;bundle-version="0.1.0",
  org.eclipse.text,
- fr.inria.diverse.melange.resource;bundle-version="0.1.0"
+ fr.inria.diverse.melange.resource;bundle-version="0.1.0",
+ org.eclipse.emf.transaction
 Import-Package: org.apache.log4j,
  org.eclipse.xtext.xbase.lib
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
In some situations I have a hard time to identify, I have transaction errors when the Melange builder is called.

It seems to be caused by modifications made to the Language resource (`res?.contents?.add(syntax)`), which in some cases must be in a `ResourceSet` with an editing domain for some reason.

To make the error disappear, I have written the following patch... but I would understand you don't use it since the problem is rather unclear. In fact this pull request is mostly there to inform you of the weird problem.
