### PR TITLE
[MelangeResource] Fix getEObject NPE (perform doAdapt first)

### DIFF
--- a/plugins/fr.inria.diverse.melange.resource/src/main/java/fr/inria/diverse/melange/resource/MelangeResourceImpl.xtend
+++ b/plugins/fr.inria.diverse.melange.resource/src/main/java/fr/inria/diverse/melange/resource/MelangeResourceImpl.xtend
@@ -73,6 +73,8 @@ class MelangeResourceImpl implements MelangeResource
 	}
 
 	override getEObject(String uriFragment) {
+		if (contentResource === null)
+			doAdapt()
 		return contentResource.getEObject(uriFragment)
 	}
 


### PR DESCRIPTION
Very small fix to avoid encountering an NPE when calling `getEObject` while the adaptation was not performed yet.