### PR TITLE
Fix melange multiple resources (caused by #91)

### DIFF
--- a/plugins/fr.inria.diverse.melange.resource/src/main/java/fr/inria/diverse/melange/resource/MelangeResourceImpl.xtend
+++ b/plugins/fr.inria.diverse.melange.resource/src/main/java/fr/inria/diverse/melange/resource/MelangeResourceImpl.xtend
@@ -337,29 +337,22 @@ class MelangeResourceImpl implements MelangeResource {
 
 			// 2 - Adapt Language to ModelType
 			if (expectedMt !== null) {
-				val result = contentResource.adaptResourceToMT(expectedMt)
-				contentResource = result
+				contentResource = contentResource.adaptResourceToMT(expectedMt)
 				addToResourceSet(contentResource)
 			}
 		}
 	}
 
 	private def void addToResourceSet(Resource res) {
-		val noRS = this.resourceSet !== null
-		val notNull = res !== null
-		if (noRS && notNull) {
-			val notExisting = !this.resourceSet.resources.contains(res)
-			if (notExisting) {
-				val withSameURI = this.resourceSet.resources.findFirst[it.URI.equals(res.URI)]
-				if (withSameURI !== null) {
+		if (this.resourceSet !== null && res !== null) {
+			if (!this.resourceSet.resources.contains(res)) {
+				if (this.resourceSet.resources.exists[it.URI.equals(res.URI)]) {
 					throw new Exception("INTERNAL ERROR: resource already loaded?!")
 				}
 				this.resourceSet.resources.add(res)
 				if (!this.resourceSet.resources.contains(res)) {
-					throw new Exception("INTERNAL ERROR: cannot load resource ?!")
+					throw new Exception("INTERNAL ERROR: cannot resource was not loaded?!")
 				}
-			} else {
-				println("test")
 			}
 		}
 	}

--- a/plugins/fr.inria.diverse.melange.resource/src/main/java/fr/inria/diverse/melange/resource/MelangeResourceImpl.xtend
+++ b/plugins/fr.inria.diverse.melange.resource/src/main/java/fr/inria/diverse/melange/resource/MelangeResourceImpl.xtend
@@ -222,11 +222,14 @@ class MelangeResourceImpl implements MelangeResource {
 		for (r : allRes) {
 			// Prepare the URI of the MelangeResource
 			var newMelangeURIString = r.URI.toString.replaceFirst("platform:/", "melange:/");
+			val separators = newLinkedList('?','&')
+
 			if (!expectedLang.isNullOrEmpty) {
-				newMelangeURIString = newMelangeURIString + "?lang=" + expectedLang
+				newMelangeURIString = newMelangeURIString + separators.head + "lang=" + expectedLang
+				separators.remove(0)
 			}
 			if (!expectedMt.isNullOrEmpty) {
-				newMelangeURIString = newMelangeURIString + "?mt=" + expectedMt
+				newMelangeURIString = newMelangeURIString + separators.head + "mt=" + expectedMt
 			}
 			val newMelangeURI = URI::createURI(newMelangeURIString)
 


### PR DESCRIPTION
Several problems were introduced by the PR https://github.com/diverse-project/melange/pull/91 , whose purpose was to have exactly one `MelangeResource` per adapted resource. Previously, this was not the case when several resources were implied, because a `MelangeResource` was only created for the originally loaded resource, not for the resources it depended on.

Yet, this broke several things, and Melange tests related to handling multiple resources did not pass anymore, mostly because `doAdapt` was not called on an indirectly created `MelangeResources`.

This fix contains the following changes:
- When creating a `MelangeResource` because of a dependency, `doAdapt` is always called (similarly to the fact that `copy` was always called for such resources before these changes)
- The `contentResource` containing an adaptation to an MT now has a unique URI based on the adapted resource and on the target MT, which also prevents `ResourceSet`-related problems and ease debugging
- The `MelangeResource` now has its own `ResourceSet`, managed by overriding `basicSetResourceSet`. This fixes problems that could occur when `getResourceSet` is delegated to the `wrappedResource`, meaning that a MelangeResource could (often very temporarily) be in a `ResourceSet.resources` while  `getResourceSet` would return a different `ResourceSet`

And this time I did not forget to run the tests successfully before offering the PR :)