### PR TITLE
generated runtime project gets GEMOC nature and builder

### DIFF
--- a/plugins/fr.inria.diverse.melange.ui/src/main/java/fr/inria/diverse/melange/ui/builder/MelangeBuilder.xtend
+++ b/plugins/fr.inria.diverse.melange.ui/src/main/java/fr/inria/diverse/melange/ui/builder/MelangeBuilder.xtend
@@ -123,7 +123,7 @@ class MelangeBuilder
 			sub.beginTask("Generating runtime for " + l.name, 100)
 			if(l.externalRuntimeName != project.name){
 				sub.subTask("Creating new project for " + l.name)
-				eclipseHelper.createEMFRuntimeProject(l.externalRuntimeName, l)
+				eclipseHelper.createGemocLangEMFRuntimeProject(l.externalRuntimeName, l)
 				subMonitor.worked(5)
 				sub.subTask("Serializing Ecore description for " + l.name)
 				l.createExternalEcore

--- a/plugins/fr.inria.diverse.melange/src/main/java/fr/inria/diverse/melange/eclipse/EclipseProjectHelper.xtend
+++ b/plugins/fr.inria.diverse.melange/src/main/java/fr/inria/diverse/melange/eclipse/EclipseProjectHelper.xtend
@@ -54,6 +54,8 @@ class EclipseProjectHelper
 {
 	@Inject extension LanguageExtensions
 	private static final Logger log = Logger.getLogger(EclipseProjectHelper)
+	
+	val String GEMOCNatureID = "org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.GemocSequentialLanguageNature"
 
 	/**
 	 * Returns the {@link IProject} containing the Melange file pointed by
@@ -239,6 +241,7 @@ class EclipseProjectHelper
 	 * Additions to the usual Melange:
 	 * <ul>
 	 *   <li>Source folders: src-model-gen</li>
+	 *   <li>Nature: GEMOC Nature</li>
 	 * </ul>
 	 */
 	def void createEMFRuntimeInMelangeProject(IProject project, Language l, IProgressMonitor monitor){
@@ -252,6 +255,17 @@ class EclipseProjectHelper
 		
 		ClasspathHelper.addSourceEntry(project,"src-model-gen", subMonitor.split(10))
 		BuildPropertiesHelper.addMainJarSourceEntry(project,"src-model-gen", subMonitor.split(10))
+		
+		// add Gemoc nature to project because it will also contain the generated dsl file
+		if (!project.hasNature(GEMOCNatureID)) {
+			val IProjectDescription description = project.getDescription()
+			val String[] natures = description.getNatureIds()
+			val String[] newNatures = newArrayOfSize(natures.length + 1)
+			System.arraycopy(natures, 0, newNatures, 1, natures.length)
+			newNatures.set(0, GEMOCNatureID)
+			description.setNatureIds(newNatures)
+			project.setDescription(description, null)
+		}
 	}
 
 	/**
@@ -269,10 +283,10 @@ class EclipseProjectHelper
 			// FIXME: Everything's hardcoded...
 			val project = createEclipseProject(
 				projectName,
-				#["org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.GemocSequentialLanguageNature", 
+				#[ GEMOCNatureID, 
 					JavaCore::NATURE_ID, PDE::PLUGIN_NATURE, "org.eclipse.xtext.ui.shared.xtextNature"
 				],
-				#["org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.GemocSequentialLanguageBuilder",
+				#[ GEMOCNatureID,
 					JavaCore::BUILDER_ID, PDE::MANIFEST_BUILDER_ID, PDE::SCHEMA_BUILDER_ID
 				],
 				#["src", "src-gen"],

--- a/plugins/fr.inria.diverse.melange/src/main/java/fr/inria/diverse/melange/eclipse/EclipseProjectHelper.xtend
+++ b/plugins/fr.inria.diverse.melange/src/main/java/fr/inria/diverse/melange/eclipse/EclipseProjectHelper.xtend
@@ -256,9 +256,55 @@ class EclipseProjectHelper
 
 	/**
 	 * Creates a new Eclipse project named {@code projectName} for the
+	 * {@link Language} {@code l}. Acting as a GEMOC Language
+	 * <ul>
+	 *   <li>Natures: GEMOCSequentialLanguage, JAVA, PLUGIN, XText</li>
+	 *   <li>Builders: GEMOCSequentialBuilder, JAVA, MANIFEST, SCHEMA</li>
+	 *   <li>Source folders: src/src-gen</li>
+	 *   <li>Dependencies: Ecore, K3, Xbase</li>
+	 * </ul>
+	 */
+	def IProject createGemocLangEMFRuntimeProject(String projectName, Language l) {
+		try {
+			// FIXME: Everything's hardcoded...
+			val project = createEclipseProject(
+				projectName,
+				#["org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.GemocSequentialLanguageNature", 
+					JavaCore::NATURE_ID, PDE::PLUGIN_NATURE, "org.eclipse.xtext.ui.shared.xtextNature"
+				],
+				#["org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.GemocSequentialLanguageBuilder",
+					JavaCore::BUILDER_ID, PDE::MANIFEST_BUILDER_ID, PDE::SCHEMA_BUILDER_ID
+				],
+				#["src", "src-gen"],
+				#[],
+				#["org.eclipse.emf.ecore",
+				  "fr.inria.diverse.k3.al.annotationprocessor.plugin",
+				  "fr.inria.diverse.melange",
+				  "org.eclipse.xtext.xbase.lib"],
+//				#[basePkg, basePkg + ".impl", basePkg + ".util"],
+				if (l.hasCopiedAspects) #[l.aspectsNamespace] else #[],
+				#[],
+				new NullProgressMonitor
+			)
+
+			val modelFolder = project.getFolder("model")
+			modelFolder.create(false, true, null)
+
+			log.debug('''Runtime EMF project «project» created.''')
+
+			return project
+		} catch (Exception e) {
+			log.error("Unexpected exception while creating new runtime project", e)
+		}
+
+		return null
+	}
+	
+	/**
+	 * Creates a new Eclipse project named {@code projectName} for the
 	 * {@link Language} {@code l}.
 	 * <ul>
-	 *   <li>Natures: JAVA, PLUGIN</li>
+	 *   <li>Natures: JAVA, PLUGIN, XText</li>
 	 *   <li>Builders: JAVA, MANIFEST, SCHEMA</li>
 	 *   <li>Source folders: src/src-gen</li>
 	 *   <li>Dependencies: Ecore, K3, Xbase</li>


### PR DESCRIPTION
as acting as a builder for GEMOC (ie. Melange project is used as a preliminary phase to create the .dsl from melange
definition) Melange also need to add GEMOC nature and builder to the
runtime language project so the dsl file is automatically registered in the plugin.xml


note: it currently use Gemoc**Sequential**LanguageNature but this should be fixed later in Gemoc in order to get a more general nature