### PR TITLE
[MelangeResource] Delay add to resource set + fix typo

### DIFF
--- a/plugins/fr.inria.diverse.melange.resource/src/main/java/fr/inria/diverse/melange/resource/MelangeResourceImpl.xtend
+++ b/plugins/fr.inria.diverse.melange.resource/src/main/java/fr/inria/diverse/melange/resource/MelangeResourceImpl.xtend
@@ -57,7 +57,6 @@ class MelangeResourceImpl implements MelangeResource {
 	}
 
 	new(ResourceSet rs, URI uri) {
-		rs.resources.add(this)
 		val query = uri.query
 		val SEPARATOR = "&|;"
 		val pairs = query?.split(SEPARATOR)
@@ -67,6 +66,7 @@ class MelangeResourceImpl implements MelangeResource {
 
 		melangeUri = uri
 		wrappedResource = rs.getResource(MelangeResourceUtils.melangeToFallbackURI(uri), true) as Resource.Internal
+		rs.resources.add(this)
 	}
 
 	override ResourceSet getResourceSet() {
@@ -351,7 +351,7 @@ class MelangeResourceImpl implements MelangeResource {
 				}
 				this.resourceSet.resources.add(res)
 				if (!this.resourceSet.resources.contains(res)) {
-					throw new Exception("INTERNAL ERROR: cannot resource was not loaded?!")
+					throw new Exception("INTERNAL ERROR: resource was not loaded?!")
 				}
 			}
 		}


### PR DESCRIPTION
When one of the `MelangeResourceImpl` constructors is called, the first line `rs.resources.add(this)` may indirectly trigger a call to `eAdapters`, which itself calls `doAdapt`:
https://github.com/diverse-project/melange/blob/e44a40081112c56046cd25307fc7d325b51bd777/plugins/fr.inria.diverse.melange.resource/src/main/java/fr/inria/diverse/melange/resource/MelangeResourceImpl.xtend#L378-L383

In such case, an NPE will be raised in `doAdapt` because the `MelangeResourceImpl` constructor should always finish its job before calling `doAdapt`.

This PR fixes this NPE by pushing the  `rs.resources.add(this)` line at the end of the constructor.